### PR TITLE
Use frankfurter API for currency rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export class CurrencyService {
 
     /* To get the current currency exchange rates based on the base provided for the given 'toCurrency' */
     getCurrency(fromCurrency: string, toCurrency: string): Observable<Currency> {
-        return this.httpClient.get<Currency>('https://ratesapi.io/api/latest?base=' + fromCurrency + '&symbols=' + toCurrency);
+        return this.httpClient.get<Currency>('https://api.frankfurter.app/latest?from=' + fromCurrency + '&to=' + toCurrency);
     }
 }
 

--- a/src/app/currency-converter/currency.service.ts
+++ b/src/app/currency-converter/currency.service.ts
@@ -11,6 +11,6 @@ export class CurrencyService {
 
     /* To get the current currency exchange rates based on the base provided for the given 'toCurrency' */
     getCurrency(fromCurrency: string, toCurrency: string): Observable<Currency> {
-        return this.httpClient.get<Currency>('https://ratesapi.io/api/latest?base=' + fromCurrency + '&symbols=' + toCurrency);
+        return this.httpClient.get<Currency>('https://api.frankfurter.app/latest?from=' + fromCurrency + '&to=' + toCurrency);
     }
 }


### PR DESCRIPTION
## Summary
- update currency service to query frankfurter API
- reflect API endpoint change in README

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: clang-format unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_685a5dc6d958832a8ff8088549c8b66b